### PR TITLE
Static dbg buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If 5V pumps are used instead, the uC will control the relay that closes the pump
 
 ## Interface
 
-TODO: Next and OK buttons allow selecting the menu options:
+Next and OK buttons allow selecting the menu options:
 
 - Global status - Summary of all plant's status
   - probably it makes sense to re-read actual values only if more than 5-10
@@ -48,7 +48,9 @@ TODO: Next and OK buttons allow selecting the menu options:
   status info
 - Calibrate sensor - Allow selection and dry/wet threshold module calibration
   - this might be unnecessary, with auto-learning on manual watering
-- Water now(?) - select a module and water it under manual command - maybe should use to auto-calibrate dry, wet(?) and watering duration values?
+- Manual Watering now - select a module and water it under manual command;
+  Current dry value is used to auto-calibrate dry level for auto watering.
+  (Do we care about watering duration?)
 - Exit/Sleep
 
 ### Screens

--- a/water_system/DebugWS.h
+++ b/water_system/DebugWS.h
@@ -6,12 +6,18 @@
 #ifdef DEBUG_ON
 #define MAX_DEBUG_MSG_LEN 80
 
-#define DEBUG(fmt, args ...)                    \
-    do {                                        \
-        char dbgbuf[MAX_DEBUG_MSG_LEN + 1];     \
-        snprintf(dbgbuf, MAX_DEBUG_MSG_LEN, "DBG: " fmt, ## args); \
-        Serial.println(dbgbuf);                 \
-    } while(0)
+extern char dbgbuf[MAX_DEBUG_MSG_LEN + 1];
+
+#define DEBUG(fmt, args ...)                                               \
+    do {                                                                   \
+        int ret = snprintf(dbgbuf, MAX_DEBUG_MSG_LEN, "D: " fmt, ## args); \
+        dbgbuf[MAX_DEBUG_MSG_LEN] = 0;                                     \
+        Serial.println(dbgbuf);                                            \
+        if ( (ret < 0) || (ret >= MAX_DEBUG_MSG_LEN)) {                    \
+            Serial.println(F(" Debug message buffer overflow !"));         \
+            system_panic_no_return();                                      \
+        };                                                                 \
+    } while (0)
 
 #define DEBUG_P(msg) Serial.print(F(msg))
 

--- a/water_system/SensorAndPump.h
+++ b/water_system/SensorAndPump.h
@@ -146,7 +146,7 @@ class SensorAndPump {
             snprintf(_buf, _bufLen, "%.2d", _dryPercentOnSampleNo(drySampleIndex));
 
             // this should be safe since we have one buffer per SensorAndPump instance
-            DEBUG_P("Dry %%: "); DEBUG("%s.", _buf);
+            DEBUG_P("Dry %: "); DEBUG("%s", _buf);
 
             return _buf;
         }

--- a/water_system/WSRuntime.cpp
+++ b/water_system/WSRuntime.cpp
@@ -9,15 +9,21 @@ void panicLEDToggle() {
     digitalWrite(LED_BUILTIN, g_panic_led);
 }
 
-void system_panic_no_return()
+void system_panic_wo_lcd_no_return()
 {
     DEBUG_P("PANIC!!!!");
 
-    lcd.setBacklight(127);
     while(true) {
         panicLEDToggle();
         delay(200);
     }
+}
+
+void system_panic_no_return()
+{
+    lcd.setBacklight(127);
+    lcd.print(F(" PANIC! \7"));
+    system_panic_wo_lcd_no_return();
 }
 
 void assert_or_panic(bool condition)

--- a/water_system/WSRuntime.h
+++ b/water_system/WSRuntime.h
@@ -6,6 +6,7 @@
 
 void panicLEDToggle();
 void system_panic_no_return();
+void system_panic_wo_lcd_no_return();
 ulong timedelta(ulong ref_timestamp, ulong now);
 
 #ifdef __AVR

--- a/water_system/WaterSystem.cpp
+++ b/water_system/WaterSystem.cpp
@@ -92,7 +92,7 @@ WaterSystem::WaterSystem(/* args */)
 
     if (error != 0) {
         setSystemInternalError();
-        system_panic_no_return();
+        system_panic_wo_lcd_no_return();
 
     } else {
         initGlyphs(lcd);

--- a/water_system/WaterSystem.cpp
+++ b/water_system/WaterSystem.cpp
@@ -5,6 +5,7 @@
 #include "WSRuntime.h"
 #include "WSMenu.h"
 
+char dbgbuf[MAX_DEBUG_MSG_LEN + 1];
 
 LiquidCrystal_PCF8574 lcd(LCD_I2C_ADDRESS);  // set the LCD address to 0x27 for a 16 chars and 2 line display
 

--- a/water_system/WaterSystem.cpp
+++ b/water_system/WaterSystem.cpp
@@ -455,7 +455,7 @@ void WaterSystem::autoWater()
 
     #define AUTOWATER_STATUS_LEN_PER_PLANT 3U
     for (uint8_t i = 0; i < MAX_MODULE_COUNT; i++) {
-        DEBUG("AW%u", i);
+        DEBUG_P("AW");DEBUG("%u", i);
 
         // just add each plant on the second row during processing
         // e.g.:  0(rain) 1(rain) 2(skip) 3(disabled)

--- a/water_system/WaterSystem.cpp
+++ b/water_system/WaterSystem.cpp
@@ -200,7 +200,7 @@ void WaterSystem::listAll()
     // the menu item
     lcd.setCursor(12, 0);
     lcd.write(_burger_menu->location());
-    lcd.print("  X");
+    lcd.print(F("  X"));
 
     lcd.setCursor(15, 1);
     if (hasInternalError())

--- a/water_system/WaterSystem.cpp
+++ b/water_system/WaterSystem.cpp
@@ -78,7 +78,7 @@ WaterSystem::WaterSystem(/* args */)
 
     while (!Serial) {};
 
-    DEBUG_P("Check 4 LCD");
+    DEBUG_P(" Check 4 LCD ");
 
     // See http://playground.arduino.cc/Main/I2cScanner
     Wire.begin();

--- a/water_system/test/mocks/WSRuntime_mock.cpp
+++ b/water_system/test/mocks/WSRuntime_mock.cpp
@@ -14,6 +14,9 @@ void system_panic_no_return() {
     EXPECT_TRUE(expectPanic);
     expectPanic = false;
 }
+void system_panic_wo_lcd_no_return(){
+    system_panic_no_return();
+}
 
 void assert_or_panic(bool condition)
 {


### PR DESCRIPTION
Runtime allocated data, be it on the stack or heap, is often a problem for memory safety, since large enough data or stacks can overwrite each other or maybe stuff in other memory regions such as .data or .bss, depending on the memory layout (i.e. linker script and program's data).

These allocations' sizes aren't that obvious at compile, and such a memory corruption error could silently exist in the system, but symptoms of it isn't necessarily obvious or visible (yay for subtle bugs /sarcasm).

In order to make the system more predictable/obvious from compile time (e.g. the static RAM usage vs. how much is left for heap/stack) it is desirable to change stack allocations into statically allocated buffers, use the heap as little as possible, and so on.

The DEBUG* macros are a source of such dynamic allocation on the stack, but given the typical linear execution of the code, it should be safe to reuse a global buffer for the DEBUG messages instead of allocating on the stack.

Even our main objects (WaterSystem, WaterAndPump, WaterSystemSM and the future logging and GeneROMst objects) could be statically allocated and use an init function instead of the constructor to do the runtime intitalization, so the RAM size usage and dynamic needs would be a lot more easier to estimate from compile time data, since only a small amount of objects/data would be on the heap and the stack. This avenue should be explored, too.